### PR TITLE
Fix template to not cause TemplateSyntaxError

### DIFF
--- a/ddt_request_history/panels/request_history.html
+++ b/ddt_request_history/panels/request_history.html
@@ -77,7 +77,7 @@
                 </td>
                 <td style="white-space: nowrap;">
                     <a class="djToggleSwitch" onclick="djdtTogglePost(this);" href="#">+</a>
-                    <span style="white-space: nowrap;">{{ toolbar.toolbar.stats.RequestHistoryPanel.post|truncatechars:200 |escape }}</span>
+                    <span style="white-space: nowrap;">{{ toolbar.toolbar.stats.RequestHistoryPanel.post|truncatechars:200|escape }}</span>
                 </td>
 			</tr>
 		{% endfor %}


### PR DESCRIPTION
The page template causes a TemplateSyntaxError to be thrown. (Might be due to an old version of django or something. Removing one space character solves the problem.)
