### PR TITLE
The history panel now shows the HTTP method (useful for APIs)

### DIFF
--- a/ddt_request_history/panels/request_history.html
+++ b/ddt_request_history/panels/request_history.html
@@ -7,6 +7,7 @@
                 <tr>
                     <th>#</th>
                     <th>{% trans "Time" %}</th>
+                    <th>{% trans "Method" %}</th>
                     <th>{% trans "Path" %}</th>
                     <th>{% trans "Post Variables" %}</th>
                 </tr>
@@ -17,6 +18,9 @@
                         <td onclick="djdt.rh.loadToolbar('{{ id }}');" style="cursor: pointer;">{{forloop.counter}}</td>
                     <td onclick="djdt.rh.loadToolbar('{{ id }}');" style="cursor: pointer;">
                             {{ toolbar.toolbar.stats.RequestHistoryPanel.time|escape }}
+                        </td>
+                        <td onclick="djdt.rh.loadToolbar('{{ id }}');" style="cursor: pointer;">
+                            <p>{{ toolbar.toolbar.stats.RequestHistoryPanel.request_method|escape }}</p>
                         </td>
                         <td onclick="djdt.rh.loadToolbar('{{ id }}');" style="cursor: pointer;">
                             <p>{{ toolbar.toolbar.stats.RequestHistoryPanel.request_url|escape }}</p>

--- a/ddt_request_history/panels/request_history.py
+++ b/ddt_request_history/panels/request_history.py
@@ -160,6 +160,7 @@ class RequestHistoryPanel(Panel):
     def process_response(self, request, response):
         self.record_stats({
             'request_url': request.get_full_path(),
+            'request_method': request.method,
             'post': json.dumps((request.POST), sort_keys=True, indent=4),
             'time': datetime.now(),
         })


### PR DESCRIPTION
It's now easier to differentiate different HTTP methods from each others. For example when an API is doing a `OPTIONS` request before a `POST` request; we can now see which one is the `OPTiONS` one and the `POST` one.

<img width="1255" alt="Screenshot 2019-04-16 at 12 09 14" src="https://user-images.githubusercontent.com/6186720/56201179-a55cb300-6040-11e9-9d00-12e6818fbb5e.png">
