### PR TITLE
fix: invalidate jquery data cache when setting store-id (for django-debug-toolbar < 1.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ Add the panel to ```DEBUG_TOOLBAR_PANELS``` (see the config section for more det
 
 ### Usage ###
 
-Click on the "Request History" panel in the toolbar to load the available requests. Click on the request you are interested in (on the "Time" or "Path" part of the request) to load the toolbar for that request.
+* Click on the "Request History" panel in the toolbar to load the available requests 
+* Click on the request you are interested in (on the "Time" or "Path" part of the request) to load the toolbar for that request
 
-**Note:** currently requests do not survive server reload, therefore, when using the dev server old requests will not be available after a code change is loaded.
+
+**Notes**
+
+Due to django-debug-toolbar reliance on thread-local:
+- currently requests do not survive server reload, therefore, when using the dev server old requests will not be available after a code change is loaded
+- if you get inconsistent request history each time you click on the panel, lower your server threads to 1
 
 
 ### Config (in settings.py) ###

--- a/ddt_request_history/panels/request_history.html
+++ b/ddt_request_history/panels/request_history.html
@@ -55,6 +55,10 @@
 
         function loadToolbar(id) {
             document.querySelector('#djDebug').setAttribute('data-store-id', id);
+            if (typeof djdt != "undefined" && djdt.jQuery) {  // using django-debug-toolbar < 1.10?
+                // invalidate jquery data cache
+                djdt.jQuery('#djDebug').removeData('store-id');
+            }
             document.querySelector('.djdt-panelContent').style.display = 'none';
             var panCon = document.querySelector('.panelContent');
             if (panCon) panCon.style.display = 'none';

--- a/ddt_request_history/panels/request_history.py
+++ b/ddt_request_history/panels/request_history.py
@@ -161,7 +161,7 @@ class RequestHistoryPanel(Panel):
         self.record_stats({
             'request_url': request.get_full_path(),
             'request_method': request.method,
-            'post': json.dumps((request.POST), sort_keys=True, indent=4),
+            'post': json.dumps(request.POST, sort_keys=True, indent=4),
             'time': datetime.now(),
         })
 


### PR DESCRIPTION
Fixes issue: https://github.com/djsutho/django-debug-toolbar-request-history/issues/25