### PR TITLE
Add LICENSE file to built distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     author='David Sutherland',
     author_email='djsutho@gmail.com',
     license='BSD',
+    license_files=['LICENSE'],
     packages=find_packages(exclude=('tests', 'example')),
     include_package_data=True,
     install_requires=['django-debug-toolbar>=2.0'],


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.