### PR TITLE
Set python_requires package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     license_files=['LICENSE'],
     packages=find_packages(exclude=('tests', 'example')),
     include_package_data=True,
+    python_requires='>=3.4',
     install_requires=['django-debug-toolbar>=2.0'],
     url='https://github.com/djsutho/django-debug-toolbar-request-history',
     download_url='https://github.com/djsutho/django-debug-toolbar-request-history/tarball/0.1.4',


### PR DESCRIPTION
This helps `pip` select correct versions based on the user's current Python version.

Since this project does not yet have unit tests/CI that I can see, I selected the version based on the trove classifiers listed in `setup.py`.